### PR TITLE
HYC-21 kill switch

### DIFF
--- a/packages/contracts/contract/README.md
+++ b/packages/contracts/contract/README.md
@@ -46,6 +46,7 @@ params:
 
 User calling this method must attach the NEAR amount corresponding to the contract's value.
 
+Panics if contract kill_switch is activated
 Panics if user is not in whitelist
 Inserts the commitment in the cotnract so that a withdraw can be made using the secrets
 
@@ -99,3 +100,13 @@ params:
   - nullifier: U256 -> nullifier you want to check
 
 true if nullifier was already spent, false otherwise
+
+7. `view_kill_switch` -> `bool`
+
+Returns current value of kill_switch variable
+
+### Owner methods
+1. `toggle_kill_switch`
+
+Can only be called by owner upon depositing 1 yoctoNEAR.
+Toggles value of kill_switch. Default is false. When true, disallows all deposits.

--- a/packages/contracts/contract/src/actions/mod.rs
+++ b/packages/contracts/contract/src/actions/mod.rs
@@ -1,3 +1,4 @@
 pub mod view;
 pub mod allowlist;
 pub mod transactions;
+pub mod owner;

--- a/packages/contracts/contract/src/actions/owner.rs
+++ b/packages/contracts/contract/src/actions/owner.rs
@@ -1,0 +1,17 @@
+use near_sdk::{env, near_bindgen, assert_one_yocto};
+
+use crate::{Contract, ContractExt};
+
+#[near_bindgen]
+impl Contract {
+  #[payable]
+  pub fn toggle_kill_switch(&mut self) {
+    assert_eq!(
+      env::predecessor_account_id(),
+      self.owner,
+      "only owner can call"
+    );
+    assert_one_yocto();
+    self.kill_switch = !self.kill_switch;
+  }
+}

--- a/packages/contracts/contract/src/actions/transactions.rs
+++ b/packages/contracts/contract/src/actions/transactions.rs
@@ -20,6 +20,8 @@ impl Contract {
       deposit_value
     );
 
+    assert!(!self.kill_switch, "kill_switch was triggered");
+
     let account_id = env::predecessor_account_id();
     let account_hash = account_hash(&account_id);
     assert!(self.allowlist.is_in_allowlist(&account_hash));

--- a/packages/contracts/contract/src/actions/view.rs
+++ b/packages/contracts/contract/src/actions/view.rs
@@ -28,4 +28,8 @@ impl Contract {
   pub fn view_was_nullifier_spent(&self, nullifier: U256) -> bool {
     self.nullifier.contains(&nullifier)
   }
+
+  pub fn view_kill_switch(&self) -> bool {
+    self.kill_switch
+  }
 }


### PR DESCRIPTION
### What does it do?
Adds kill switch functionality

### Any helpful background information?
Functionality is useful for us to halt the contract in case any attempt of money laundery flows through it. It will block further deposits, allowing us time to rethink the strategy.

All deposite funds will be protected however, and can still be withdrawn 

### Any new dependencies? Why were they added?
No

### Relevant screenshots/gifs
No
