### PR TITLE
feat(front): select help and modal contact us

### DIFF
--- a/packages/front/src/components/layout/needHelp.tsx
+++ b/packages/front/src/components/layout/needHelp.tsx
@@ -1,12 +1,67 @@
+import { Listbox, Transition } from "@headlessui/react";
 import { QuestionMarkCircleIcon } from "@heroicons/react/24/outline";
+import { Fragment, useState } from "react";
+import NeedHelpModal from "../modals/needHelp";
 
 export const NeedHelp = () => {
+  const [showModal, setShowModal] = useState<boolean>(false);
+
   return (
-    <p
-      className="absolute flex items-center justify-center gap-2 px-2 rounded-[20px] text-soft-blue text-sm font-normal bg-white border-[2px] border-soft-blue p-1 top-28 right-16 cursor-not-allowed"
-      title="Coming soon"
-    >
-      Need help <QuestionMarkCircleIcon className="w-4 h-4" />
-    </p>
+    <>
+      <Listbox>
+        <div className="absolute top-28 right-7 xl:right-16 mt-1 z-50">
+          <Listbox.Button className="flex items-center justify-center gap-2 px-2 rounded-[20px] text-soft-blue text-sm font-normal bg-white border-[2px] border-soft-blue p-1">
+            Need help <QuestionMarkCircleIcon className="w-4 h-4" />
+          </Listbox.Button>
+          <Transition
+            as={Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Listbox.Options className="mt-1 flex flex-col w-full max-w-[110px] gap-2 max-h-60 overflow-auto rounded-[15px] bg-white py-2 px-2 text-base shadow-[0_4px_15px_rgba(0,0,0,0.2)] ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm z-[10]">
+              <Listbox.Option
+                value="FAQ"
+                className={({ active }) =>
+                  `text-sm text-dark-grafiti cursor-pointer px-2 ${
+                    active ? "hover:bg-soft-blue-normal rounded-[5px]" : ""
+                  }`
+                }
+                as="a"
+                href="/#faq"
+              >
+                FAQ
+              </Listbox.Option>
+              <Listbox.Option
+                value="Tutorials"
+                className={({ active }) =>
+                  `text-sm text-dark-grafiti cursor-pointer px-2 ${
+                    active ? "hover:bg-soft-blue-normal rounded-[5px]" : ""
+                  }`
+                }
+                as="a"
+                href="/#faq"
+              >
+                Tutorials
+              </Listbox.Option>
+              <Listbox.Option
+                value="Contact us"
+                className={({ active }) =>
+                  `${active ? "hover:bg-soft-blue-normal rounded-[5px]" : ""}`
+                }
+              >
+                <button
+                  className="text-sm text-dark-grafiti px-2"
+                  onClick={() => setShowModal(true)}
+                >
+                  Contact us
+                </button>
+              </Listbox.Option>
+            </Listbox.Options>
+          </Transition>
+        </div>
+      </Listbox>
+      <NeedHelpModal isOpen={showModal} onClose={() => setShowModal(false)} />
+    </>
   );
 };

--- a/packages/front/src/components/modals/needHelp/index.tsx
+++ b/packages/front/src/components/modals/needHelp/index.tsx
@@ -1,0 +1,224 @@
+import { Dialog, Transition } from "@headlessui/react";
+import { XMarkIcon } from "@heroicons/react/24/outline";
+import { Fragment } from "react";
+import * as yup from "yup";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { useForm } from "react-hook-form";
+import axios from "axios";
+import { toast } from "react-toastify";
+import { ToastCustom } from "@/components/shared/toast-custom";
+
+interface FormProps {
+  name: string;
+  email: string;
+  message: string;
+}
+
+const contactUsSchema = yup.object().shape({
+  name: yup.string().min(2, "Minimun 2 letters").required("Required field"),
+  email: yup
+    .string()
+    .email("This email is not valid")
+    .required("Required field"),
+  message: yup.string().min(2, "Minumim 2 letters").required("Required field"),
+});
+
+const NeedHelpModal = ({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormProps>({ resolver: yupResolver(contactUsSchema) });
+
+  const onSubmit = async (data: FormProps) => {
+    try {
+      await axios.post(
+        "https://formsubmit.co/ajax/hideyourcash@gmail.com",
+        data,
+        {
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+      reset();
+      onClose();
+      toast(
+        <ToastCustom
+          icon="check-circle-icon.svg"
+          title="Message sent"
+          message="Thank you for contacting us, your message will be answered shortly."
+        />
+      );
+    } catch (error) {
+      console.error(error);
+      toast(
+        <ToastCustom
+          icon="error-circle-icon.svg"
+          title="Error sending message"
+          message="Something went wrong sending your message, wait a few minutes and try again."
+        />
+      );
+    }
+  };
+
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-[100000]" onClose={onClose}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="w-full max-w-[620px] transform overflow-hidden rounded-[35px] bg-white p-6 text-left align-middle shadow-xl transition-all relative">
+                <button
+                  onClick={() => onClose()}
+                  className="absolute right-[24px] top-[24px] hover:opacity-[0.7]"
+                >
+                  <XMarkIcon className="text-black w-[24px]" />
+                </button>
+
+                <Dialog.Title
+                  as="h1"
+                  className="text-dark-grafiti-medium text-xl font-bold text-center mb-5"
+                >
+                  Contact us
+                </Dialog.Title>
+                <form onSubmit={handleSubmit(onSubmit)}>
+                  <div className="flex flex-col gap-2 mb-2 sm:flex-row">
+                    <div className="w-full">
+                      <label
+                        className={`${
+                          errors.name?.message
+                            ? "text-error"
+                            : "text-dark-grafiti"
+                        }`}
+                      >
+                        Your name{" "}
+                        {errors.name?.message && `- ${errors.name.message}`}
+                      </label>
+                      <input
+                        {...register("name")}
+                        type="text"
+                        name="name"
+                        placeholder="Write your name here"
+                        className={`
+                      p-[8px]
+                      h-[43px]
+                      bg-soft-blue-normal
+                      rounded-[15px]
+                      text-dark-grafiti-light
+                      w-full
+                      flex items-center justify-between
+                      border-[2px]
+                      ${
+                        errors.name?.message
+                          ? "border-error"
+                          : "border-transparent"
+                      }
+                      focus:outline-none`}
+                      />
+                    </div>
+                    <div className="w-full">
+                      <label
+                        className={`${
+                          errors.email?.message
+                            ? "text-error"
+                            : "text-dark-grafiti"
+                        }`}
+                      >
+                        Your email{" "}
+                        {errors.email?.message && `- ${errors.email.message}`}
+                      </label>
+                      <input
+                        {...register("email")}
+                        name="email"
+                        placeholder="example@email.com"
+                        className={`p-[8px]
+                      h-[43px]
+                      bg-soft-blue-normal
+                      rounded-[15px]
+                      text-dark-grafiti-light
+                      w-full
+                      flex items-center justify-between
+                      border-[2px]
+                      ${
+                        errors.email?.message
+                          ? "border-error"
+                          : "border-transparent"
+                      }
+                      focus:outline-none`}
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <label
+                      className={`${
+                        errors.message?.message
+                          ? "text-error"
+                          : "text-dark-grafiti"
+                      }`}
+                    >
+                      Your message{" "}
+                      {errors.message?.message && `- ${errors.message.message}`}
+                    </label>
+                    <textarea
+                      {...register("message")}
+                      name="message"
+                      placeholder="Write your message here"
+                      className={`resize-none p-[8px]
+                    h-[160px]
+                    bg-soft-blue-normal
+                    rounded-[15px]
+                    text-dark-grafiti-light
+                    w-full
+                    flex items-center justify-between
+                    border-[2px]
+                    ${
+                      errors.message?.message
+                        ? "border-error"
+                        : "border-transparent"
+                    }
+                    focus:outline-none`}
+                    />
+                  </div>
+                  <button
+                    type="submit"
+                    className="bg-soft-blue-from-deep-blue p-[12px] rounded-full block w-full mt-2 mx-auto font-[400] hover:opacity-[.9] disabled:opacity-[.6] disabled:cursor-not-allowed"
+                  >
+                    Send
+                  </button>
+                </form>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+};
+
+export default NeedHelpModal;

--- a/packages/front/src/components/modals/needHelp/index.tsx
+++ b/packages/front/src/components/modals/needHelp/index.tsx
@@ -37,15 +37,11 @@ const NeedHelpModal = ({
     formState: { errors },
   } = useForm<FormProps>({ resolver: yupResolver(contactUsSchema) });
 
-  const onSubmit = async (data: FormProps) => {
+  const onSubmit = (data: FormProps) => {
     try {
-      await axios.post(
-        "https://formsubmit.co/ajax/hideyourcash@gmail.com",
-        data,
-        {
-          headers: { "Content-Type": "application/json" },
-        }
-      );
+      axios.post("https://formsubmit.co/ajax/hideyourcash@gmail.com", data, {
+        headers: { "Content-Type": "application/json" },
+      });
       reset();
       onClose();
       toast(
@@ -207,7 +203,7 @@ const NeedHelpModal = ({
                   </div>
                   <button
                     type="submit"
-                    className="bg-soft-blue-from-deep-blue p-[12px] rounded-full block w-full mt-2 mx-auto font-[400] hover:opacity-[.9] disabled:opacity-[.6] disabled:cursor-not-allowed"
+                    className="bg-soft-blue-from-deep-blue p-[12px] rounded-full block w-full mt-6 mx-auto font-[400] hover:opacity-[.9] disabled:opacity-[.6] disabled:cursor-not-allowed"
                   >
                     Send
                   </button>

--- a/packages/front/src/pages/hideyourcash.tsx
+++ b/packages/front/src/pages/hideyourcash.tsx
@@ -77,7 +77,6 @@ export function Index() {
         </Container>
       </div>
       <AboutUsModal isOpen={showModal} onClose={() => setShowModal(false)} />
-      <Feedback />
       <NeedHelp />
     </>
   );

--- a/packages/front/src/pages/index.tsx
+++ b/packages/front/src/pages/index.tsx
@@ -9,7 +9,8 @@ import Fade from "react-reveal/Fade";
 import HeaderLanding from "@/components/layout/header-landing";
 import Card from "@/components/shared/card";
 import MiniCard from "@/components/shared/mini-card";
-import { useApplication } from "@/store";
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const Waves = () => {
   return (
@@ -34,6 +35,13 @@ const Index = () => {
   useEffect(() => {
     document.body.style.background =
       "linear-gradient(90deg, #ffffff -1.75%, #d5eef4 105.87%)";
+
+    (async () => {
+      if (location.hash === "#faq") {
+        await delay(100);
+        window.scrollTo(0, document.body.scrollHeight);
+      }
+    })();
   }, []);
 
   return (


### PR DESCRIPTION
### URL to Jira task (this should explain the task)
[URL to jira](https://hackachain.atlassian.net/jira/software/projects/HYC/boards/11?selectedIssue=HYC-155)
### Explain what the code alterations do
The changes cause the need help button to open a select so that the user selects the help option he wants. FAQ redirects to the FAQ section on the landing page, Tutorials redirects to a youtube video (for now it does not have the docs) and Contact us opens a modal with a form to fill and send a more specific message to the adms
### What has to be tested? How to test it?
Redirects and modal must be tested. To test them just click on the need help button and choose any of the 3 options, if you choose Contact us, test the modal trying to send without filling in the fields, putting a text in the email field and writing less than 2 words in the inputs 
### Any new dependencies? Why were they added?
No new dependency